### PR TITLE
Add get all notes route

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,38 @@ Jot is my back-end capstone built while at [Nashville Software School](http://na
 ## API Endpoints
 These endpoints are here for developer access and not open to the public.  To access most of these endpoints, you must be logged into the application.
 ### /notes
+/notes/
+Returns all given user's notes with all keyords and each note's most recent edit date.
+```
+[
+  {
+    "id": 1,
+    "text": "This is an example note.",
+    "user_id": 1,
+    "Keywords": [
+      {
+        "id": 1,
+        "keyword": "example",
+        "user_selected": true,
+        "note_id": 1
+      },
+      {
+        "id": 2,
+        "keyword": "note",
+        "user_selected": true,
+        "note_id": 1
+      }
+    ],
+    "Note_Dates": [
+      {
+        "id": 1,
+        "edit_date": "2018-04-30T21:27:14.209Z",
+        "note_id": 1
+      }
+    ]
+  }
+]
+```
 /notes/:id 
 Returns given note with all keywords and it's most recent edit date.
 ```

--- a/server/controllers/noteCtrl.js
+++ b/server/controllers/noteCtrl.js
@@ -1,8 +1,7 @@
 'use strict';
 
-module.exports.getNote = (req, res, next) => {
+module.exports.getOneNote = (req, res, next) => {
   const { Note, Keyword, Note_Date } = req.app.get('models');
-  // if (!req.body.noteId) return next();
 
   const noteId = req.params.id;
   Note.findAll({
@@ -18,7 +17,29 @@ module.exports.getNote = (req, res, next) => {
     },
   })
     .then(note => {
-      note ? res.status(200).json(note) : res.status(204).sends();
+      res.status(200).json(note);
+    })
+    .catch(err => next(err))
+};
+
+module.exports.getAllNotes = (req, res, next) => {
+  const { Note, Keyword, Note_Date } = req.app.get('models');
+
+  const userId = req.user.id;
+  Note.findAll({
+    include: [{
+      model: Keyword,
+    }, {
+      model: Note_Date,
+      limit: 1,
+      order: [['edit_date', 'DESC']],
+    }],
+    where: {
+      user_id: userId,
+    },
+  })
+    .then(notes => {
+      res.status(200).json(notes);
     })
     .catch(err => next(err))
 };

--- a/server/routes/notesRoute.js
+++ b/server/routes/notesRoute.js
@@ -6,9 +6,11 @@ const passport = require('passport');
 const { isLoggedIn } = require('./routeHelpers');
 
 const {
-  getNote,
+  getOneNote,
+  getAllNotes,
 } = require('../controllers/noteCtrl.js');
 
-router.get('/note/:id', isLoggedIn, getNote);
+router.get('/notes/:id', isLoggedIn, getOneNote);
+router.get('/notes/', isLoggedIn, getAllNotes);
 
 module.exports = router;


### PR DESCRIPTION
# Issue
Completes issue #4 (Get all notes route).

# Description
Returns all notes for a given user, with each note's keywords, and most recent edit date.

# Testing
When you navigate to /notes/ when not logged in, it should re-route you to the login page.  When you are logged in and go there, you should receive an array of note objects.  Example below:
```
[
  {
    "id": 1,
    "text": "This is an example note.",
    "user_id": 1,
    "Keywords": [
      {
        "id": 1,
        "keyword": "example",
        "user_selected": true,
        "note_id": 1
      },
      {
        "id": 2,
        "keyword": "note",
        "user_selected": true,
        "note_id": 1
      }
    ],
    "Note_Dates": [
      {
        "id": 1,
        "edit_date": "2018-04-30T21:27:14.209Z",
        "note_id": 1
      }
    ]
  }
]
```