### PR TITLE
Add delete note route

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Jot is my back-end capstone built while at [Nashville Software School](http://na
 ## API Endpoints
 These endpoints are here for developer access and not open to the public.  To access most of these endpoints, you must be logged into the application.
 ### /notes
-/notes/
+GET /notes/
 Returns all given user's notes with all keyords and each note's most recent edit date.
 ```
 [
@@ -36,7 +36,7 @@ Returns all given user's notes with all keyords and each note's most recent edit
   }
 ]
 ```
-/notes/:id 
+GET /notes/:id 
 Returns given note with all keywords and it's most recent edit date.
 ```
 [
@@ -67,5 +67,10 @@ Returns given note with all keywords and it's most recent edit date.
     ]
   }
 ]
+```
+DELETE /notes/:id
+Deletes the specified note.  Returns the number of rows deleted.  If none were deleted, 0 is returned.
+```
+1
 ```
 ___

--- a/server/controllers/noteCtrl.js
+++ b/server/controllers/noteCtrl.js
@@ -43,3 +43,20 @@ module.exports.getAllNotes = (req, res, next) => {
     })
     .catch(err => next(err))
 };
+
+module.exports.deleteNote = (req, res, next) => {
+  const { Note } = req.app.get('models');
+
+  // Only the note has to be deleted,
+  // becasue the database is setup to cascade delete.
+  const noteId = req.params.id;
+  Note.destroy({
+    where: {
+      id: noteId,
+    },
+  })
+    .then(rowsDestroyed => {
+      res.status(200).json(rowsDestroyed);
+    })
+    .catch(err => next(err))
+};

--- a/server/routes/notesRoute.js
+++ b/server/routes/notesRoute.js
@@ -8,9 +8,11 @@ const { isLoggedIn } = require('./routeHelpers');
 const {
   getOneNote,
   getAllNotes,
+  deleteNote,
 } = require('../controllers/noteCtrl.js');
 
 router.get('/notes/:id', isLoggedIn, getOneNote);
 router.get('/notes/', isLoggedIn, getAllNotes);
+router.delete('/notes/:id', isLoggedIn, deleteNote);
 
 module.exports = router;


### PR DESCRIPTION
# Issue
Completes issue #7  (Add delete note route)

# Description
Adds '/notes/:id' route to delete a note if you are logged in.

# Testing
When not logged in, sending a delete to /notes/:id will send you to the login page.  When logged in, it will return the number of rows deleted per the example below.  If none are deleted, it will return 0.
```
0
```