### PR TITLE
Add get user options and patch user options

### DIFF
--- a/server/controllers/noteCtrl.js
+++ b/server/controllers/noteCtrl.js
@@ -62,16 +62,22 @@ module.exports.getOneNote = (req, res, next) => {
   Note.findAll({
     include: [{
       model: Keyword,
+      attributes: {
+        exclude: ['id', 'note_id'],
+      },
     }, {
       model: Note_Date,
       limit: 1,
       order: [['edit_date', 'DESC']],
+      attributes: {
+        exclude: ['id'],
+      },
     }],
     where: {
       id: noteId,
     },
   })
-    .then(note => {
+    .then(([note]) => {
       res.status(200).json(note);
     })
     .catch(err => next(err))
@@ -84,6 +90,9 @@ module.exports.getAllNotes = (req, res, next) => {
   Note.findAll({
     include: [{
       model: Keyword,
+      attributes: {
+        exclude: ['id', 'note_id'],
+      },
     }, {
       model: Note_Date,
       limit: 1,

--- a/server/controllers/noteCtrl.js
+++ b/server/controllers/noteCtrl.js
@@ -97,6 +97,9 @@ module.exports.getAllNotes = (req, res, next) => {
       model: Note_Date,
       limit: 1,
       order: [['edit_date', 'DESC']],
+      attributes: {
+        exclude: ['id'],
+      },
     }],
     where: {
       user_id: userId,

--- a/server/controllers/noteCtrl.js
+++ b/server/controllers/noteCtrl.js
@@ -55,6 +55,8 @@ const clearOldKeywords = ({ Keyword, noteId }) => {
   }));
 };
 
+// When trying to exclude note_id from Note_Date, sequelize throws an error.  
+// Excluding note_id when limiting doesn't work right now in sequelize.
 module.exports.getOneNote = (req, res, next) => {
   const { Note, Keyword, Note_Date } = req.app.get('models');
 
@@ -83,6 +85,8 @@ module.exports.getOneNote = (req, res, next) => {
     .catch(err => next(err))
 };
 
+// When trying to exclude note_id from Note_Date, sequelize throws an error.  
+// Excluding note_id when limiting doesn't work right now in sequelize.
 module.exports.getAllNotes = (req, res, next) => {
   const { Note, Keyword, Note_Date } = req.app.get('models');
 
@@ -95,8 +99,8 @@ module.exports.getAllNotes = (req, res, next) => {
       },
     }, {
       model: Note_Date,
-      limit: 1,
       order: [['edit_date', 'DESC']],
+      limit: 1,
       attributes: {
         exclude: ['id'],
       },

--- a/server/controllers/userCtrl.js
+++ b/server/controllers/userCtrl.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports.getUserInfo = (req, res, next) => {
+  const { User, Option } = req.app.get('models');
+
+  const userId = req.user.id;
+  User.findAll({
+    include: [{
+      model: Option,
+      attributes: {
+        exclude: ['id', 'user_id'],
+      },
+    }],
+    where: {
+      id: userId,
+    },
+    attributes: {
+      exclude: ['password'],
+    },
+  })
+    .then(([userInfo]) => {
+      res.status(200).json(userInfo);
+    })
+    .catch(err => next(err));
+};

--- a/server/controllers/userCtrl.js
+++ b/server/controllers/userCtrl.js
@@ -51,7 +51,7 @@ module.exports.updateOption = (req, res, next) => {
       user_id: userId,
     },
   })
-    .then(rowsUpdated => {
+    .then(([rowsUpdated]) => {
       res.status(200).json(rowsUpdated);
     })
     .catch(err => next(err));

--- a/server/controllers/userCtrl.js
+++ b/server/controllers/userCtrl.js
@@ -23,3 +23,36 @@ module.exports.getUserInfo = (req, res, next) => {
     })
     .catch(err => next(err));
 };
+
+module.exports.updateOption = (req, res, next) => {
+  const { Option } = req.app.get('models');
+
+  const userId = req.user.id;
+
+  const {
+    font_size,
+    font_style,
+    auto_keyword_style,
+    user_keyword_style,
+  } = req.body;
+
+  const updateObject = {
+    user_id: userId,
+  };
+  
+  // Only add values to patch object if present on req.body.
+  if (typeof font_size !== undefined) updateObject.font_size = font_size;
+  if (typeof font_style !== undefined) updateObject.font_style = font_style;
+  if (typeof auto_keyword_style !== undefined) updateObject.auto_keyword_style = auto_keyword_style;
+  if (typeof user_keyword_style !== undefined) updateObject.user_keyword_style = user_keyword_style;
+
+  Option.update(updateObject, {
+    where: {
+      user_id: userId,
+    },
+  })
+    .then(rowsUpdated => {
+      res.status(200).json(rowsUpdated);
+    })
+    .catch(err => next(err));
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,5 +7,6 @@ const router = Router();
 router.use(require('./authRoute'));
 
 router.use(require('./notesRoute'));
+router.use(require('./userRoute'));
 
 module.exports = router;

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -7,8 +7,10 @@ const { isLoggedIn } = require('./routeHelpers');
 
 const {
   getUserInfo,
+  updateOption,
 } = require('../controllers/userCtrl.js');
 
 router.get('/currentUser/', isLoggedIn, getUserInfo);
+router.patch('/currentUser/', isLoggedIn, updateOption);
 
 module.exports = router;

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { Router } = require('express');
+const router = Router();
+const passport = require('passport');
+const { isLoggedIn } = require('./routeHelpers');
+
+const {
+  getUserInfo,
+} = require('../controllers/userCtrl.js');
+
+router.get('/currentUser/', isLoggedIn, getUserInfo);
+
+module.exports = router;


### PR DESCRIPTION
# Issue
Completes Issues #13  & #16 .

# Description
Adds a patch and get method to /currentUser/ to get the current user's options or patch their option.

# Testing
When you patch or get /currentUser/ when not logged in, you should be redirected to the login page.
When you get /currentUser/ and are logged in, you should be returned the current user's information (example below) without their password.
```
{
  "id": 1,
  "display_name": "Tim",
  "email": "a@a.com",
  "creation_date": "1970-01-18T15:38:40.916Z",
  "Option": {
    "font_size": 25,
    "font_style": "blue",
    "auto_keyword_style": "italic",
    "user_keyword_style": "bold"
  }
}
```
When you patch to /currentUser/ with any of the given properties on the request object: 
```
font_size,
font_style,
auto_keyword_style,
user_keyword_style,
```
Only the ones provided should update the database.  A 200 code and the number of rows modified will be returned if it is successful.